### PR TITLE
RWA-113 - Add listener to Camunda to call task configuration service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 build
 out/
 .secrets
+gradle.properties

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -7,9 +7,16 @@ def product = "camunda"
 def app = "bpm"
 
 def secrets = [
+    'camunda-${env}' : [
         secret('camunda-enterprise-user', 'ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_USER'),
         secret('camunda-enterprise-password', 'ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_PASSWORD'),
+    ],
+    's2s-${env}': [
+        secret('microservicekey-wa-task-management-api', 'S2S_SECRET_TASK_MANAGEMENT_API'),
     ]
+]
+
+
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [
@@ -22,12 +29,16 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 
 withPipeline(type, product, app) {
- after('checkout') {
+
+    after('checkout') {
     withAzureKeyvault( azureKeyVaultSecrets: secrets,
                        keyVaultURLOverride: 'https://rpe-prod.vault.azure.net') {
         env.ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_USER = env.ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_USER
         env.ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_PASSWORD = env.ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_PASSWORD
      }
   }
-  enableDbMigration("camunda")
+
+    env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+
+    enableDbMigration("camunda")
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,11 +6,13 @@ def type = "java"
 def product = "camunda"
 def app = "bpm"
 
+
 def secrets = [
-    'camunda-${env}' : [
-        secret('camunda-enterprise-user', 'ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_USER'),
-        secret('camunda-enterprise-password', 'ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_PASSWORD'),
-    ],
+    secret('camunda-enterprise-user', 'ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_USER'),
+    secret('camunda-enterprise-password', 'ORG_GRADLE_PROJECT_CAMUNDA_NEXUS_PASSWORD'),
+]
+
+def vaultSecrets = [
     's2s-${env}': [
         secret('microservicekey-wa-task-management-api', 'S2S_SECRET_TASK_MANAGEMENT_API'),
     ]
@@ -29,6 +31,8 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 
 withPipeline(type, product, app) {
+
+    loadVaultSecrets(vaultSecrets)
 
     after('checkout') {
     withAzureKeyvault( azureKeyVaultSecrets: secrets,

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -39,6 +39,7 @@ withPipeline(type, product, app) {
   }
 
     env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+    env.TASK_CONFIGURATION_URL = "http://wa-task-configuration-api-aat.service.core-compute-aat.internal"
 
     enableDbMigration("camunda")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -190,13 +190,6 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.2.16'
     implementation 'org.flywaydb:flyway-core:6.5.4'
 
-    //Jax-B Dependencies
-    implementation "javax.xml.bind:jaxb-api:2.3.1"
-//    implementation "javax.activation:activation:1.1.1"
-    implementation "com.sun.xml.bind:jaxb-impl:3.0.0"
-    implementation "org.glassfish.jaxb:jaxb-runtime:3.0.0"
-
-
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.logging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.logging
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,8 @@ dependencyManagement {
         mavenBom 'org.camunda.bpm:camunda-bom:7.13.3-ee'
     }
     dependencies {
+        // CVE-2020-26945 - Mishandles deserialization of object streams.
+        dependency group: 'org.mybatis', name: 'mybatis', version: '3.5.6'
         // CVE-2018-10237 - Unbounded memory allocation
         dependencySet(group: 'com.google.guava', version: '29.0-jre') {
             entry 'guava'

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencyUpdates {
 
 def versions = [
         logging: '5.1.7',
+        junit: '5.7.0',
+        junitPlatform   : '1.7.0',
+
 ]
 
 checkstyle {
@@ -65,6 +68,16 @@ dependencyCheck {
 }
 
 sourceSets {
+
+    testUtils {
+        java {
+            compileClasspath += main.output
+            runtimeClasspath += main.output
+            srcDir file('src/testUtils/java')
+        }
+        resources.srcDir file('src/testUtils/resources')
+    }
+
     smokeTest {
         java {
             compileClasspath += main.output
@@ -73,14 +86,25 @@ sourceSets {
         }
         resources.srcDir file('src/smokeTest/resources')
     }
+
     functionalTest {
         java {
-            compileClasspath += main.output
-            runtimeClasspath += main.output
+            compileClasspath += testUtils.output
+            runtimeClasspath += testUtils.output
             srcDir file('src/functionalTest/java')
         }
         resources.srcDir file('src/functionalTest/resources')
     }
+
+    integrationTest {
+        java {
+            compileClasspath += testUtils.output
+            runtimeClasspath += testUtils.output
+            srcDir file('src/integrationTest/java')
+        }
+        resources.srcDir file('src/integrationTest/resources')
+    }
+
 
 }
 
@@ -95,15 +119,26 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
     classpath = sourceSets.functionalTest.runtimeClasspath
 }
 
+task integration(type: Test) {
+    description = "Runs integration tests"
+    group = "Verification"
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    failFast = true
+}
+
+
 jacocoTestReport {
-    executionData(test)
+    executionData(test, integration)
     reports {
         xml.enabled = true
         csv.enabled = false
         xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
     }
 }
-project.tasks['sonarqube'].dependsOn jacocoTestReport
+
+project.tasks['sonarqube'].dependsOn test, integration, jacocoTestReport
+
 sonarqube {
     properties {
         property "sonar.projectName", "Reform :: camunda-bpm"
@@ -113,7 +148,16 @@ sonarqube {
     }
 }
 
-ext["rest-assured.version"] = '4.3.1'
+ext.libraries = [
+    "rest-assured": { version = '4.3.1' },
+    junit5: [
+        "org.junit.jupiter:junit-jupiter-api:${versions.junit}",
+        "org.junit.jupiter:junit-jupiter-engine:${versions.junit}",
+        "org.junit.jupiter:junit-jupiter-params:${versions.junit}",
+        "org.junit.platform:junit-platform-commons:${versions.junitPlatform}",
+        "org.junit.platform:junit-platform-engine:${versions.junitPlatform}"
+    ]
+]
 
 dependencyManagement {
     imports {
@@ -146,6 +190,13 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.2.16'
     implementation 'org.flywaydb:flyway-core:6.5.4'
 
+    //Jax-B Dependencies
+    implementation "javax.xml.bind:jaxb-api:2.3.1"
+//    implementation "javax.activation:activation:1.1.1"
+    implementation "com.sun.xml.bind:jaxb-impl:3.0.0"
+    implementation "org.glassfish.jaxb:jaxb-runtime:3.0.0"
+
+
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.logging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.logging
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
@@ -156,6 +207,22 @@ dependencies {
     testImplementation 'org.camunda.bpm.extension:camunda-bpm-assert-scenario:1.0.0'
     testImplementation 'org.slf4j:jul-to-slf4j:1.7.30'
     testImplementation 'org.testcontainers:postgresql:1.14.3'
+
+    testCompile "com.github.tomakehurst:wiremock-jre8:2.27.2"
+    testCompile "org.junit.vintage:junit-vintage-engine:${versions.junit}"
+
+    testImplementation libraries.junit5
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
+        exclude group: 'junit', module: 'junit'
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+
+    testUtilsImplementation sourceSets.main.runtimeClasspath
+    testUtilsImplementation sourceSets.test.runtimeClasspath
+
+    integrationTestImplementation sourceSets.main.runtimeClasspath
+    integrationTestImplementation sourceSets.test.runtimeClasspath
+    integrationTestImplementation "org.junit.vintage:junit-vintage-engine:${versions.junit}"
 
     smokeTestImplementation sourceSets.main.runtimeClasspath
     smokeTestImplementation sourceSets.test.runtimeClasspath
@@ -175,8 +242,13 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
+tasks.withType(Test) {
+    useJUnitPlatform()
 
-
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
 
 flyway {
     url = System.getenv('FLYWAY_URL')

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ import org.flywaydb.gradle.task.FlywayMigrateTask
 plugins {
     id 'application'
     id 'checkstyle'
-    id 'com.github.ben-manes.versions' version '0.33.0'
-    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'com.github.ben-manes.versions' version '0.36.0'
+    id 'org.springframework.boot' version '2.3.7.RELEASE'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-    id 'org.flywaydb.flyway' version '6.5.5'
-    id 'org.owasp.dependencycheck' version '6.0.2'
+    id 'org.flywaydb.flyway' version '6.5.7'
+    id 'org.owasp.dependencycheck' version '6.0.5'
     id 'org.sonarqube' version '3.0'
     id 'jacoco'
 }
@@ -169,8 +169,12 @@ dependencyManagement {
     dependencies {
         // CVE-2020-26945 - Mishandles deserialization of object streams.
         dependency group: 'org.mybatis', name: 'mybatis', version: '3.5.6'
-        // CVE-2018-10237 - Unbounded memory allocation
-        dependencySet(group: 'com.google.guava', version: '29.0-jre') {
+        // CVE-2020-29242, CVE-2020-29243, CVE-2020-29244, CVE-2020-29245 - check spring-boot-starter-oauth2-client for lang-tag update
+        dependency group: 'com.nimbusds', name: 'lang-tag', version: '1.5'
+        // CVE-2020-13956 - misinterpret malformed authority component in request URIs - check for update available to com.warrenstrange:googleauth in service-auth-provider-client
+        dependency group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+        // CVE-2020-8908 - Temp directory creation vulnerability
+        dependencySet(group: 'com.google.guava', version: '30.1-jre') {
             entry 'guava'
         }
     }
@@ -188,12 +192,15 @@ dependencies {
     implementation 'org.camunda.bpm:camunda-engine-plugin-spin'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.postgresql:postgresql:42.2.16'
-    implementation 'org.flywaydb:flyway-core:6.5.4'
+    implementation 'org.flywaydb:flyway-core:6.5.7'
+    // JAX-B dependencies for JDK 9+
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.0'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:3.0.0'
 
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.logging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.logging
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
-    implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
+    implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.4'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.camunda.bpm.extension:camunda-bpm-assert:1.2'
@@ -272,10 +279,10 @@ configurations.all {
     resolutionStrategy {
         eachDependency { DependencyResolveDetails details ->
             if (details.requested.group in ['com.fasterxml.jackson.core', 'com.fasterxml.jackson.module', 'com.fasterxml.jackson.datatype']) {
-                details.useVersion '2.11.2'
+                details.useVersion '2.12.1'
             }
             if (details.requested.group in ['org.apache.tomcat.embed']) {
-                details.useVersion '9.0.39'
+                details.useVersion '9.0.41'
             }
             // Rest Assured 4.3.0 uses groovy 3
             if (details.requested.group in ['org.codehaus.groovy']) {

--- a/charts/camunda-bpm/Chart.yaml
+++ b/charts/camunda-bpm/Chart.yaml
@@ -1,6 +1,6 @@
 name: camunda-bpm
 home: https://github.com/hmcts/camunda-bpm
-version: 0.0.12
+version: 0.0.13
 description: Camunda bpm
 maintainers:
   - name: HMCTS Platform engineering team

--- a/charts/camunda-bpm/values.preview.template.yaml
+++ b/charts/camunda-bpm/values.preview.template.yaml
@@ -12,5 +12,7 @@ java:
     SPRING_FLYWAY_ENABLED: false
     SPRING_CLOUD_PROPERTIESVOLUME_ENABLED: false
     CAMUNDA_DB_CONN_OPTIONS: ""
+    S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    TASK_CONFIGURATION_URL: "http://wa-task-configuration-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
   postgresql:
     enabled: true

--- a/charts/camunda-bpm/values.yaml
+++ b/charts/camunda-bpm/values.yaml
@@ -13,4 +13,5 @@ java:
     CAMUNDA_DB_USER_NAME: "camundaadmin@hmcts-camunda-{{ .Values.global.environment }}"
     CAMUNDA_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     CAMUNDA_DB_CONN_OPTIONS: ?sslmode=require&gssEncMode=disable
-    S2S_URL: rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    TASK_CONFIGURATION_URL: "http://wa-task-configuration-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -70,4 +70,10 @@
    ]]></notes>
     <cve>CVE-2020-13943</cve>
   </suppress>
+  <suppress until="2022-01-01">
+    <notes><![CDATA[
+     Suppressing as it's already set to use jackson-databind 2.12.1
+   ]]></notes>
+    <cve>CVE-2020-25649</cve>
+  </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+CAMUNDA_NEXUS_USER=ministry_of_justice_uk
+CAMUNDA_NEXUS_PASSWORD=53e6ad1a-3bb7-4d17-a
+

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -31,3 +31,26 @@ resource "azurerm_key_vault_secret" "camunda-admin-password" {
   value        = random_string.password.result
   key_vault_id = module.vault.key_vault_id
 }
+
+data "azurerm_key_vault" "key_vault" {
+  name                = "${var.raw_product}-${var.env}"
+  resource_group_name = "${var.raw_product}-${var.env}"
+}
+
+data "azurerm_key_vault" "s2s_key_vault" {
+  name                = "s2s-${var.env}"
+  resource_group_name = "rpe-service-auth-provider-${var.env}"
+}
+
+
+data "azurerm_key_vault_secret" "s2s_secret" {
+  key_vault_id = data.azurerm_key_vault.s2s_key_vault.id
+  name      = "microservicekey-camunda-bpm"
+}
+
+# Copy camunda-bpm s2s secret from s2s key vault to camunda key vault
+resource "azurerm_key_vault_secret" "camunda_bpm_s2s_secret" {
+  name         = "s2s-secret-camunda-bpm"
+  value        = data.azurerm_key_vault_secret.s2s_secret.value
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -2,13 +2,19 @@ variable "common_tags" {
   type = "map"
 }
 
+variable "raw_product" {
+  default = "camunda"
+}
+
 variable "product" {}
 
 variable "component" {}
 
 variable "subscription" {}
 
-variable "env" {}
+variable "env" {
+  type = "string"
+}
 
 variable "location" {
   default = "UK South"

--- a/infrastructure/vault.tf
+++ b/infrastructure/vault.tf
@@ -6,7 +6,7 @@ module "vault" {
   tenant_id                  = var.tenant_id
   object_id                  = var.jenkins_AAD_objectId
   resource_group_name        = azurerm_resource_group.rg.name
-  product_group_object_id    = "300e771f-856c-45cc-b899-40d78281e9c1"
+  product_group_object_id    = "e7ea2042-4ced-45dd-8ae3-e051c6551789"
   create_managed_identity    = true
   common_tags                = var.common_tags
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/camunda/bpm/clients/TaskConfigurationServiceApiTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/camunda/bpm/clients/TaskConfigurationServiceApiTest.java
@@ -1,0 +1,161 @@
+package uk.gov.hmcts.reform.camunda.bpm.clients;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.ResourceUtils;
+import uk.gov.hmcts.reform.camunda.bpm.SpringBootIntegrationBaseTest;
+import uk.gov.hmcts.reform.camunda.bpm.domain.request.ConfigureTaskRequest;
+import uk.gov.hmcts.reform.camunda.bpm.domain.response.ConfigureTaskResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+class TaskConfigurationServiceApiTest extends SpringBootIntegrationBaseTest {
+
+    private static final String CASE_ID = "CASE_12345";
+    private static final String TASK_NAME = "A task name";
+    private static final String USER_ID = "someUserId";
+    private static final String SERVICE_TOKEN = "S2S_TOKEN";
+    private static WireMockServer wireMockServer;
+    private String taskId;
+
+
+    @Autowired
+    private TaskConfigurationServiceApi taskConfigurationServiceApi;
+
+
+    @BeforeAll
+    static void configure() {
+        wireMockServer = new WireMockServer(8888);
+        wireMockServer.start();
+
+    }
+
+    @AfterAll
+    static void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        taskId = UUID.randomUUID().toString();
+    }
+
+    @Test
+    void should_respond_with_correct_variables_with_no_auto_assignment() throws IOException {
+
+        stubTaskConfigurationServiceApiResponse(
+            loadJsonResponseFromFile("task-configuration-response-no-auto-assignment.json")
+        );
+
+        ConfigureTaskResponse response = taskConfigurationServiceApi.configureTask(
+            SERVICE_TOKEN,
+            taskId,
+            new ConfigureTaskRequest(getRequiredVariables())
+        );
+
+        Map<String, Object> expectedConfigurationVariables = getDefaultExpectedVariables();
+        expectedConfigurationVariables.put("autoAssigned", false);
+        expectedConfigurationVariables.put("taskState", "unassigned");
+
+        assertThat(response).isNotNull();
+        assertThat(response.getAssignee()).isNull();
+        assertThat(response.getTaskId()).isEqualTo(taskId);
+        assertThat(response.getCaseId()).isEqualTo(CASE_ID);
+        assertThat(response.getConfigurationVariables()).isEqualTo(expectedConfigurationVariables);
+    }
+
+    @Test
+    void should_respond_with_correct_variables_with_auto_assignment() throws IOException {
+
+        stubTaskConfigurationServiceApiResponse(
+            loadJsonResponseFromFile("task-configuration-response-auto-assignment.json")
+        );
+
+        ConfigureTaskResponse response = taskConfigurationServiceApi.configureTask(
+            SERVICE_TOKEN,
+            taskId,
+            new ConfigureTaskRequest(getRequiredVariables())
+        );
+
+        Map<String, Object> expectedConfigurationVariables = getDefaultExpectedVariables();
+        expectedConfigurationVariables.put("autoAssigned", true);
+        expectedConfigurationVariables.put("taskState", "assigned");
+
+        assertThat(response).isNotNull();
+        assertThat(response.getAssignee()).isEqualTo(USER_ID);
+        assertThat(response.getTaskId()).isEqualTo(taskId);
+        assertThat(response.getCaseId()).isEqualTo(CASE_ID);
+        assertThat(response.getConfigurationVariables()).isEqualTo(expectedConfigurationVariables);
+    }
+
+
+    private void stubTaskConfigurationServiceApiResponse(String response) {
+        String url = "/task/" + taskId + "/configuration";
+        wireMockServer.stubFor(
+            post(urlEqualTo(url))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", APPLICATION_JSON_VALUE)
+                        .withBody(response))
+        );
+    }
+
+    private String loadJsonResponseFromFile(String fileName) throws IOException {
+        String response = FileUtils.readFileToString(
+            ResourceUtils.getFile("classpath:responses/" + fileName));
+
+        response = response.replace("{TASK_ID}", taskId)
+            .replace("{CASE_ID}", CASE_ID)
+            .replace("{TASK_NAME}", TASK_NAME)
+            .replace("{USER_ID}", USER_ID);
+
+        return response;
+
+    }
+
+    private Map<String, Object> getRequiredVariables() {
+        return
+            Map.of(
+                "caseId", CASE_ID,
+                "name", TASK_NAME
+            );
+
+    }
+
+
+    private Map<String, Object> getDefaultExpectedVariables() {
+
+        Map<String, Object> defaultExpectedVariables = new HashMap<>();
+        defaultExpectedVariables.put("appealType", "protection");
+        defaultExpectedVariables.put("caseId", CASE_ID);
+        defaultExpectedVariables.put("caseName", "Bob Smith");
+        defaultExpectedVariables.put("caseTypeId", "Asylum");
+        defaultExpectedVariables.put("executionType", "Case Management Task");
+        defaultExpectedVariables.put("location", "765324");
+        defaultExpectedVariables.put("locationName", "Taylor House");
+        defaultExpectedVariables.put("region", "1");
+        defaultExpectedVariables.put("securityClassification", "PUBLIC");
+        defaultExpectedVariables.put("senior-tribunal-caseworker", "Read,Refer,Own,Manage,Cancel");
+        defaultExpectedVariables.put("taskSystem", "SELF");
+        defaultExpectedVariables.put("title", TASK_NAME);
+        defaultExpectedVariables.put("tribunal-caseworker", "Read,Refer,Own,Manage,Cancel");
+
+        return defaultExpectedVariables;
+    }
+
+}

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -1,0 +1,2 @@
+task-configuration-api:
+  url: http://localhost:8888

--- a/src/integrationTest/resources/responses/task-configuration-response-auto-assignment.json
+++ b/src/integrationTest/resources/responses/task-configuration-response-auto-assignment.json
@@ -1,0 +1,22 @@
+{
+  "task_id": "{TASK_ID}",
+  "assignee": "{USER_ID}",
+  "case_id": "{CASE_ID}",
+  "configuration_variables": {
+    "tribunal-caseworker": "Read,Refer,Own,Manage,Cancel",
+    "caseTypeId": "Asylum",
+    "locationName": "Taylor House",
+    "executionType": "Case Management Task",
+    "securityClassification": "PUBLIC",
+    "autoAssigned": true,
+    "taskSystem": "SELF",
+    "title": "{TASK_NAME}",
+    "taskState": "assigned",
+    "appealType": "protection",
+    "caseId": "{CASE_ID}",
+    "caseName": "Bob Smith",
+    "location": "765324",
+    "region": "1",
+    "senior-tribunal-caseworker": "Read,Refer,Own,Manage,Cancel"
+  }
+}

--- a/src/integrationTest/resources/responses/task-configuration-response-no-auto-assignment.json
+++ b/src/integrationTest/resources/responses/task-configuration-response-no-auto-assignment.json
@@ -1,0 +1,21 @@
+{
+  "task_id": "{TASK_ID}",
+  "case_id": "{CASE_ID}",
+  "configuration_variables": {
+    "tribunal-caseworker": "Read,Refer,Own,Manage,Cancel",
+    "caseTypeId": "Asylum",
+    "locationName": "Taylor House",
+    "executionType": "Case Management Task",
+    "securityClassification": "PUBLIC",
+    "autoAssigned": false,
+    "taskSystem": "SELF",
+    "title": "{TASK_NAME}",
+    "taskState": "unassigned",
+    "appealType": "protection",
+    "caseId": "{CASE_ID}",
+    "caseName": "Bob Smith",
+    "location": "765324",
+    "region": "1",
+    "senior-tribunal-caseworker": "Read,Refer,Own,Manage,Cancel"
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/CamundaApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/CamundaApplication.java
@@ -6,10 +6,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableProcessApplication("example-processs")
+@EnableFeignClients(basePackages =
+    {
+        "uk.gov.hmcts.reform.authorisation",
+        "uk.gov.hmcts.reform.camunda.bpm",
+    })
 public class CamundaApplication {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/clients/TaskConfigurationServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/clients/TaskConfigurationServiceApi.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.camunda.bpm.clients;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.reform.camunda.bpm.config.FeignClientSnakeCaseConfiguration;
+import uk.gov.hmcts.reform.camunda.bpm.domain.request.ConfigureTaskRequest;
+import uk.gov.hmcts.reform.camunda.bpm.domain.response.ConfigureTaskResponse;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.camunda.bpm.config.ServiceTokenGeneratorConfiguration.SERVICE_AUTHORIZATION;
+
+@FeignClient(
+    name = "task-configuration-api",
+    url = "${task-configuration-api.url}",
+    configuration = FeignClientSnakeCaseConfiguration.class
+)
+@SuppressWarnings("checkstyle:LineLength")
+public interface TaskConfigurationServiceApi {
+
+    @PostMapping(
+        value = "/task/{task-id}/configuration",
+        consumes = APPLICATION_JSON_VALUE
+    )
+    ConfigureTaskResponse configureTask(@RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthToken,
+                                        @PathVariable("task-id") String taskId,
+                                        @RequestBody ConfigureTaskRequest body);
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/EventHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/EventHandlerConfiguration.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.camunda.bpm.config;
+
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.camunda.bpm.services.TaskConfigurationService;
+
+@Component
+class EventHandlerConfiguration {
+
+    /*
+     This assignee id is used as a blacklist
+     to ignore tasks created with this assignee usually created for testing purposes
+     */
+
+    private static final String TEST_PURPOSES_ASSIGNEE_ID = "demo";
+    private final TaskConfigurationService taskConfigurationService;
+
+    public EventHandlerConfiguration(TaskConfigurationService taskConfigurationService) {
+        this.taskConfigurationService = taskConfigurationService;
+    }
+
+    @EventListener
+    public void onTaskCreatedEvent(DelegateTask delegateTask) {
+        System.out.println("called");
+
+        // Avoid the first 2 demo tasks that get created for testing purposes on application startup
+        if (!TEST_PURPOSES_ASSIGNEE_ID.equals(delegateTask.getAssignee())) {
+
+
+            /*
+             Uses DelegateTask as it is a mutable object
+             Call wa-task-configuration to retrieve configuration for a tasks.
+             The reason it is done in this way is because the tasks does not yet exist in the database
+             when this event is triggered
+             */
+
+
+            taskConfigurationService.configureTask(delegateTask);
+        }
+
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/FeignClientSnakeCaseConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/FeignClientSnakeCaseConfiguration.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.camunda.bpm.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignClientSnakeCaseConfiguration {
+    @Bean
+    public Decoder feignDecoder() {
+        return new JacksonDecoder(snakeCaseObjectMapper());
+    }
+
+    @Bean
+    public Encoder feignEncoder() {
+        return new JacksonEncoder(snakeCaseObjectMapper());
+    }
+
+    public ObjectMapper snakeCaseObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/ServiceTokenGeneratorConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.camunda.bpm.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
+
+@Configuration
+@Lazy
+public class ServiceTokenGeneratorConfiguration {
+
+    public static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
+
+    @Bean
+    public AuthTokenGenerator authTokenGenerator(
+        @Value("${idam.s2s-auth.secret}") String secret,
+        @Value("${idam.s2s-auth.name}") String microService,
+        ServiceAuthorisationApi serviceAuthorisationApi
+    ) {
+        return AuthTokenGeneratorFactory.createDefaultGenerator(
+            secret,
+            microService,
+            serviceAuthorisationApi
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/domain/request/ConfigureTaskRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/domain/request/ConfigureTaskRequest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.camunda.bpm.domain.request;
+
+import java.util.Map;
+
+public class ConfigureTaskRequest {
+    private Map<String, Object> processVariables;
+
+    private ConfigureTaskRequest() {
+        //No-op constructor for deserialization
+    }
+
+    public ConfigureTaskRequest(Map<String, Object> processVariables) {
+        this.processVariables = processVariables;
+    }
+
+    public Map<String, Object> getProcessVariables() {
+        return processVariables;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/domain/response/ConfigureTaskResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/domain/response/ConfigureTaskResponse.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.camunda.bpm.domain.response;
+
+import java.util.Map;
+
+public class ConfigureTaskResponse {
+    private String taskId;
+    private String caseId;
+    private String assignee;
+    private Map<String, Object> configurationVariables;
+
+    private ConfigureTaskResponse() {
+        //No-op constructor for deserialization
+    }
+
+    public ConfigureTaskResponse(String taskId,
+                                 String caseId,
+                                 String assignee,
+                                 Map<String, Object> configurationVariables) {
+        this.taskId = taskId;
+        this.caseId = caseId;
+        this.assignee = assignee;
+        this.configurationVariables = configurationVariables;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public String getCaseId() {
+        return caseId;
+    }
+
+    public String getAssignee() {
+        return assignee;
+    }
+
+    public Map<String, Object> getConfigurationVariables() {
+        return configurationVariables;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/exception/ServerErrorException.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/exception/ServerErrorException.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.camunda.bpm.exception;
+
+public class ServerErrorException extends RuntimeException {
+
+    private static final long serialVersionUID = 6107753640554124324L;
+
+    public ServerErrorException(
+        String message,
+        Throwable cause
+    ) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/services/FeignRetryPolicy.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/services/FeignRetryPolicy.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.reform.camunda.bpm.services;
+
+import feign.FeignException;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+
+import java.util.function.Supplier;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class FeignRetryPolicy<T> {
+    private static final Logger LOG = getLogger(FeignRetryPolicy.class);
+    private final int maxRetries;
+    private int retryCount;
+
+    public FeignRetryPolicy(int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    // Takes a function and executes it, if fails, passes the function to the retry command
+    public T run(Supplier<T> function) {
+        try {
+            return function.get();
+        } catch (Exception ex) {
+            if (ex.getCause() != null && ex.getCause() instanceof FeignException) {
+                FeignException rootException = (FeignException) ex.getCause();
+                if (HttpStatus.NOT_FOUND.value() == rootException.status()) {
+                    LOG.error("Non retryable exception was received, call will be aborted.");
+                    return null;
+                } else {
+                    return retry(function);
+                }
+            } else {
+                LOG.error(
+                    "An unexpected error occurred while making a call with retry policy, call will be aborted");
+                return null;
+            }
+        }
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    private T retry(Supplier<T> function) {
+        LOG.warn("Call failed, The call will be retried {} times.", maxRetries);
+        retryCount = 0;
+        while (retryCount < maxRetries) {
+            try {
+                return function.get();
+            } catch (Exception ex) {
+                if (ex.getCause() != null && ex.getCause() instanceof FeignException) {
+                    FeignException rootException = (FeignException) ex.getCause();
+                    if (HttpStatus.NOT_FOUND.value() == rootException.status()) {
+                        //Should not retry
+                        LOG.error("Non retryable exception was received, call will be aborted.");
+                        break;
+                    }
+                    // increment retry count and check for max retries exceed
+                    retryCount++;
+                    LOG.warn("[{}/{}] - Call failed on retry.", retryCount, maxRetries);
+                    if (retryCount >= maxRetries) {
+                        LOG.error("Maximum allowed retries exceeded.");
+                        break;
+                    }
+                } else {
+                    LOG.error(
+                        "An unexpected error occurred while making a call with retry policy, call will be aborted");
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationService.java
@@ -1,0 +1,90 @@
+package uk.gov.hmcts.reform.camunda.bpm.services;
+
+import feign.FeignException;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.camunda.bpm.clients.TaskConfigurationServiceApi;
+import uk.gov.hmcts.reform.camunda.bpm.domain.request.ConfigureTaskRequest;
+import uk.gov.hmcts.reform.camunda.bpm.domain.response.ConfigureTaskResponse;
+import uk.gov.hmcts.reform.camunda.bpm.exception.ServerErrorException;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class TaskConfigurationService {
+
+    private static final int MAX_RETRIES = 3;
+    private final TaskConfigurationServiceApi taskConfigurationServiceApi;
+    private final AuthTokenGenerator authTokenGenerator;
+    private final FeignRetryPolicy<ConfigureTaskResponse> withFeignRetryPolicy;
+
+
+    @Autowired
+    public TaskConfigurationService(AuthTokenGenerator authTokenGenerator,
+                                    TaskConfigurationServiceApi taskConfigurationServiceApi
+    ) {
+        this.authTokenGenerator = authTokenGenerator;
+        this.taskConfigurationServiceApi = taskConfigurationServiceApi;
+        withFeignRetryPolicy = new FeignRetryPolicy<>(MAX_RETRIES);
+    }
+
+    public void configureTask(DelegateTask task) {
+        requireNonNull(task.getId(), "taskId cannot be null");
+        Map<String, Object> variables = task.getVariables();
+
+        ConfigureTaskResponse response = withFeignRetryPolicy.run(
+            () -> performConfigureTaskAction(task.getId(), new ConfigureTaskRequest(variables)
+            ));
+
+
+        // If the call resulted in a non-retryable exception update the task state to unconfigured only.
+        if (response == null) {
+            task.setVariable("taskState", "unconfigured");
+        } else {
+
+            /*
+              Merge old original variables with the new ones from the response.
+              Favouring the response process variables as they might contain updates.
+            */
+            Map<String, Object> mergedVariables = Stream.concat(
+                variables.entrySet().stream(),
+                response.getConfigurationVariables().entrySet().stream())
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (oldValue, newValue) -> oldValue.equals(newValue) ? oldValue : newValue)
+                );
+
+            // If response contained an assignee also update mutable object's assignee
+            if (response.getAssignee() != null) {
+                task.setAssignee(response.getAssignee());
+            }
+            // Update task mutable object with merged process variables
+            task.setVariables(mergedVariables);
+        }
+    }
+
+
+    private ConfigureTaskResponse performConfigureTaskAction(String taskId, ConfigureTaskRequest configureTaskRequest) {
+        try {
+            return taskConfigurationServiceApi.configureTask(
+                authTokenGenerator.generate(),
+                taskId,
+                configureTaskRequest
+            );
+        } catch (FeignException ex) {
+            throw new ServerErrorException(
+                String.format(
+                    "There was a problem configuring the task with id: %s",
+                    taskId
+                ), ex);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,8 @@ management:
     web:
       base-path: /
 spring:
+  main:
+    allow-bean-definition-overriding: true
   flyway:
     enabled: false
   security:
@@ -23,7 +25,7 @@ camunda:
   api:
     auth:
       enabled: true
-  ui: 
+  ui:
     auth:
       enabled: false
   bpm:
@@ -85,6 +87,12 @@ server:
 idam:
   s2s-auth:
     url: ${S2S_URL:http://localhost:4552}
+    name: ${S2S_NAME_CAMUNDA_BPM:camunda_bpm}
+    secret: ${S2S_SECRET_CAMUNDA_BPM:AAAAAAAAAAAAAAAA}
+
+task-configuration-api:
+  url: ${TASK_CONFIGURATION_URL:http://localhost:8091}
+
 ---
 spring:
   profiles: springauth
@@ -107,3 +115,4 @@ camunda:
   ui:
     auth:
       enabled: true
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,20 +47,31 @@ camunda:
     webapp:
       application-path: /
 camundaGroups:
-  rpe:
-    adGroupId: c36eaede-a0ae-4967-8fed-0a02960b1370
-    tenantId: rpe
-    groupId: rpe
+  platops:
+    adGroupId: e7ea2042-4ced-45dd-8ae3-e051c6551789
+    tenantId: platops
+    groupId: platops
     accessControl: user
   work-allocation:
     adGroupId: cdeb331b-adfe-46a7-a2c8-a628e2d35d96
-    tenantId: work-allocation
-    groupId: work-allocation
+    tenantId: wa
+    groupId: wa
     accessControl: user
     s2sServiceNames:
       - wa_task_management_api
       - wa_task_configuration_api
       - wa_workflow_api
+      - wa_case_event_handler
+  ia:
+    adGroupId: b16db4e7-5cd6-409a-9f10-632089d91ff5
+    tenantId: ia
+    groupId: ia
+    accessControl: user
+    s2sServiceNames:
+      - wa_task_management_api
+      - wa_task_configuration_api
+      - wa_workflow_api
+      - wa_case_event_handler
   civil-unspecified:
     adGroupId: 40c33f5a-24d0-4b22-a923-df8a80a59cd9
     tenantId: civil-unspecified
@@ -69,7 +80,7 @@ camundaGroups:
     s2sServiceNames:
       - unspec-service
 
-camundaAdminGroupId: c36eaede-a0ae-4967-8fed-0a02960b1370
+camundaAdminGroupId: e7ea2042-4ced-45dd-8ae3-e051c6551789
 camundaAccess:
   user:
     deploymentAccess: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,14 +95,7 @@ server:
   servlet:
     context-path: /
   port: 8999
-idam:
-  s2s-auth:
-    url: ${S2S_URL:http://localhost:4552}
-    name: ${S2S_NAME_CAMUNDA_BPM:camunda_bpm}
-    secret: ${S2S_SECRET_CAMUNDA_BPM:AAAAAAAAAAAAAAAA}
 
-task-configuration-api:
-  url: ${TASK_CONFIGURATION_URL:http://localhost:8091}
 
 ---
 spring:
@@ -127,3 +120,11 @@ camunda:
     auth:
       enabled: true
 
+idam:
+  s2s-auth:
+    url: ${S2S_URL:http://localhost:4552}
+    name: ${S2S_NAME_CAMUNDA_BPM:camunda_bpm}
+    secret: ${S2S_SECRET_CAMUNDA_BPM:AAAAAAAAAAAAAAAA}
+
+task-configuration-api:
+  url: ${TASK_CONFIGURATION_URL:http://localhost:8091}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,6 +96,14 @@ server:
     context-path: /
   port: 8999
 
+idam:
+  s2s-auth:
+    url: ${S2S_URL:http://localhost:4552}
+    name: ${S2S_NAME_CAMUNDA_BPM:camunda_bpm}
+    secret: ${S2S_SECRET_CAMUNDA_BPM:AAAAAAAAAAAAAAAA}
+
+task-configuration-api:
+  url: ${TASK_CONFIGURATION_URL:http://localhost:8091}
 
 ---
 spring:
@@ -120,11 +128,3 @@ camunda:
     auth:
       enabled: true
 
-idam:
-  s2s-auth:
-    url: ${S2S_URL:http://localhost:4552}
-    name: ${S2S_NAME_CAMUNDA_BPM:camunda_bpm}
-    secret: ${S2S_SECRET_CAMUNDA_BPM:AAAAAAAAAAAAAAAA}
-
-task-configuration-api:
-  url: ${TASK_CONFIGURATION_URL:http://localhost:8091}

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -8,3 +8,4 @@ spring:
         openid-client-id: spring.security.oauth2.client.registration.azure.client-id
         openid-client-secret: spring.security.oauth2.client.registration.azure.client-secret
         camunda-admin-password: CAMUNDA_ADMIN_PASSWORD
+        s2s-secret-camunda-bpm: S2S_SECRET_CAMUNDA_BPM

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/FeignRetryPolicyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/FeignRetryPolicyTest.java
@@ -1,0 +1,203 @@
+package uk.gov.hmcts.reform.camunda.bpm.services;
+
+import camundajar.impl.com.google.gson.Gson;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import feign.FeignException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.camunda.bpm.domain.response.ConfigureTaskResponse;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FeignRetryPolicyTest {
+
+    private static final int MAX_RETRIES = 3;
+
+    private FeignRetryPolicy<ConfigureTaskResponse> withFeignRetryPolicy;
+
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @Before
+    public void setUp() {
+
+        Logger logger = (Logger) LoggerFactory.getLogger(FeignRetryPolicy.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+
+        logger.addAppender(listAppender);
+
+        withFeignRetryPolicy = spy(new FeignRetryPolicy<>(MAX_RETRIES));
+    }
+
+    @Test
+    public void should_not_retry_when_successful() {
+
+        ConfigureTaskResponse responseMock = mock(ConfigureTaskResponse.class);
+        Supplier<ConfigureTaskResponse> methodCall = () -> responseMock;
+
+        ConfigureTaskResponse result = withFeignRetryPolicy.run(methodCall);
+
+        assertEquals(result, responseMock);
+        assertEquals(0, withFeignRetryPolicy.getRetryCount());
+
+    }
+
+
+    @Test
+    public void should_catch_other_exceptions_not_retry_and_return_null() {
+
+        Supplier<ConfigureTaskResponse> methodCall = () -> {
+            throw new IllegalArgumentException("another exception");
+        };
+
+        ConfigureTaskResponse result = withFeignRetryPolicy.run(methodCall);
+
+        assertNull(result);
+        assertEquals(0, withFeignRetryPolicy.getRetryCount());
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertEquals(
+            "An unexpected error occurred while making a call with retry policy, call will be aborted",
+            logsList.get(0).getFormattedMessage());
+        assertEquals(Level.ERROR, logsList.get(0).getLevel());
+
+    }
+
+    @Test
+    public void should_only_retry_once_and_succeed() {
+
+        ConfigureTaskResponse responseMock = mock(ConfigureTaskResponse.class);
+
+        FeignException exception = mock(FeignException.class);
+
+        Supplier<ConfigureTaskResponse> methodCall = () -> {
+            if (withFeignRetryPolicy.getRetryCount() == 0) {
+                throw exception;
+            } else {
+                return responseMock;
+            }
+        };
+
+        ConfigureTaskResponse result = withFeignRetryPolicy.run(methodCall);
+
+        assertEquals(result, responseMock);
+        assertEquals(1, withFeignRetryPolicy.getRetryCount());
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertEquals("Call failed, The call will be retried 3 times.", logsList.get(0).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(0).getLevel());
+
+        assertEquals("[1/3] - Call failed on retry.", logsList.get(1).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(1).getLevel());
+    }
+
+    @Test
+    public void should_return_null_when_max_retries_is_reached() {
+
+        FeignException exception = mock(FeignException.class);
+
+        Supplier<ConfigureTaskResponse> methodCall = () -> {
+            throw exception;
+        };
+
+        ConfigureTaskResponse result = withFeignRetryPolicy.run(methodCall);
+
+        assertNull(result);
+        assertEquals(3, withFeignRetryPolicy.getRetryCount());
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertEquals("Call failed, The call will be retried 3 times.", logsList.get(0).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(0).getLevel());
+
+        assertEquals("[1/3] - Call failed on retry.", logsList.get(1).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(1).getLevel());
+
+        assertEquals("[2/3] - Call failed on retry.", logsList.get(2).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(2).getLevel());
+
+        assertEquals("[3/3] - Call failed on retry.", logsList.get(3).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(3).getLevel());
+
+        assertEquals("Maximum allowed retries exceeded.", logsList.get(4).getFormattedMessage());
+        assertEquals(Level.ERROR, logsList.get(4).getLevel());
+    }
+
+    @Test
+    public void should_return_null_when_non_retryable_exception_is_thrown() {
+
+        FeignException exception = mock(FeignException.class);
+
+        when(exception.status()).thenReturn(HttpStatus.NOT_FOUND.value());
+
+        Supplier<ConfigureTaskResponse> methodCall = () -> {
+            throw exception;
+        };
+
+        ConfigureTaskResponse result = withFeignRetryPolicy.run(methodCall);
+
+        assertNull(result);
+        assertEquals(0, withFeignRetryPolicy.getRetryCount());
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertEquals(
+            "Non retryable exception was received, call will be aborted.",
+            logsList.get(0).getFormattedMessage()
+        );
+        assertEquals(Level.ERROR, logsList.get(0).getLevel());
+
+    }
+
+
+    @Test
+    public void should_return_null_and_retry_once_first_call_is_unsuccessful_and_then_non_retryable_exception() {
+
+        FeignException exception = mock(FeignException.class);
+
+        FeignException nonRetryableException = mock(FeignException.class);
+        when(nonRetryableException.status()).thenReturn(HttpStatus.NOT_FOUND.value());
+
+        Supplier<ConfigureTaskResponse> methodCall = () -> {
+            if (withFeignRetryPolicy.getRetryCount() == 0) {
+                throw exception;
+            } else {
+                throw nonRetryableException;
+            }
+        };
+
+        ConfigureTaskResponse result = withFeignRetryPolicy.run(methodCall);
+
+        assertNull(result);
+        assertEquals(1, withFeignRetryPolicy.getRetryCount());
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        Gson g = new Gson();
+        assertEquals("Call failed, The call will be retried 3 times.", logsList.get(0).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(0).getLevel());
+
+        assertEquals("[1/3] - Call failed on retry.", logsList.get(1).getFormattedMessage());
+        assertEquals(Level.WARN, logsList.get(1).getLevel());
+
+        assertEquals(
+            "Non retryable exception was received, call will be aborted.",
+            logsList.get(2).getFormattedMessage()
+        );
+        assertEquals(Level.ERROR, logsList.get(2).getLevel());
+
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
@@ -1,0 +1,187 @@
+package uk.gov.hmcts.reform.camunda.bpm.services;
+
+import feign.FeignException;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.camunda.bpm.clients.TaskConfigurationServiceApi;
+import uk.gov.hmcts.reform.camunda.bpm.domain.request.ConfigureTaskRequest;
+import uk.gov.hmcts.reform.camunda.bpm.domain.response.ConfigureTaskResponse;
+import uk.gov.hmcts.reform.camunda.bpm.exception.ServerErrorException;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TaskConfigurationServiceTest {
+
+
+    private static final String CASE_ID = "CASE_123456789";
+    private static final String TASK_NAME = "A task name";
+    private static final String SERVICE_TOKEN = "Bearer SERVICE_TOKEN";
+    private TaskConfigurationService taskConfigurationService;
+    @Mock
+    private TaskConfigurationServiceApi taskConfigurationServiceApi;
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+    @Spy
+    private DelegateTask testTask;
+    private String taskId;
+
+    @Before
+    public void setUp() {
+        taskConfigurationService = new TaskConfigurationService(authTokenGenerator, taskConfigurationServiceApi);
+
+        taskId = UUID.randomUUID().toString();
+
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(testTask.getId()).thenReturn(taskId);
+        when(testTask.getVariables())
+            .thenReturn(getRequiredVariables());
+
+    }
+
+    @Test
+    public void should_throw_exception_if_id_is_null() {
+
+        when(testTask.getId()).thenReturn(null);
+        assertThatThrownBy(() -> taskConfigurationService.configureTask(testTask))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("taskId cannot be null")
+            .hasNoCause();
+    }
+
+    @Test
+    public void should_successfully_update_the_mutable_object_with_new_values_and_no_assignee() {
+
+        Map<String, Object> responseProcessVariables =
+            Map.of(
+                "caseTypeId", "Asylum",
+                "taskState", "unassigned",
+                "executionType", "Case Management Task",
+                "caseId", CASE_ID,
+                "securityClassification", "PUBLIC",
+                "autoAssigned", false,
+                "taskSystem", "SELF");
+
+        when(taskConfigurationServiceApi.configureTask(
+            eq(SERVICE_TOKEN),
+            eq(taskId),
+            any(ConfigureTaskRequest.class)
+        )).thenReturn(
+            new ConfigureTaskResponse(
+                taskId,
+                CASE_ID,
+                null,
+                responseProcessVariables
+            )
+        );
+
+        taskConfigurationService.configureTask(testTask);
+
+        Map<String, Object> expectedVariables =
+            Map.of(
+                "caseTypeId", "Asylum",
+                "taskState", "unassigned",
+                "executionType", "Case Management Task",
+                "caseId", CASE_ID,
+                "securityClassification", "PUBLIC",
+                "autoAssigned", false,
+                "taskSystem", "SELF",
+                "name", TASK_NAME
+            );
+
+        verify(testTask, times(0)).setAssignee(any());
+        verify(testTask, times(1)).setVariables(expectedVariables);
+
+    }
+
+    @Test
+    public void should_successfully_update_the_mutable_object_with_new_values_and_auto_assignment() {
+
+        String assignee = UUID.randomUUID().toString();
+
+        Map<String, Object> responseProcessVariables =
+            Map.of(
+                "caseTypeId", "Asylum",
+                "taskState", "assigned",
+                "executionType", "Case Management Task",
+                "caseId", CASE_ID,
+                "securityClassification", "PUBLIC",
+                "autoAssigned", true,
+                "taskSystem", "SELF");
+
+        when(taskConfigurationServiceApi.configureTask(
+            eq(SERVICE_TOKEN),
+            eq(taskId),
+            any(ConfigureTaskRequest.class)
+        )).thenReturn(
+            new ConfigureTaskResponse(
+                taskId,
+                CASE_ID,
+                assignee,
+                responseProcessVariables
+            )
+        );
+
+        taskConfigurationService.configureTask(testTask);
+
+        Map<String, Object> expectedVariables =
+            Map.of(
+                "caseTypeId", "Asylum",
+                "taskState", "assigned",
+                "executionType", "Case Management Task",
+                "caseId", CASE_ID,
+                "securityClassification", "PUBLIC",
+                "autoAssigned", true,
+                "taskSystem", "SELF",
+                "name", TASK_NAME
+            );
+
+        verify(testTask, times(1)).setAssignee(assignee);
+        verify(testTask, times(1)).setVariables(expectedVariables);
+
+    }
+
+    @Test
+    public void should_throw_server_error_exception_when_feign_exception() {
+
+        when(taskConfigurationServiceApi.configureTask(
+            eq(SERVICE_TOKEN),
+            eq(taskId),
+            any(ConfigureTaskRequest.class)
+        )).thenThrow(FeignException.FeignServerException.class);
+        assertThatThrownBy(() -> taskConfigurationService.configureTask(testTask))
+            .isInstanceOf(ServerErrorException.class)
+            .hasMessage(
+                String.format(
+                    "There was a problem configuring the task with id: %s",
+                    taskId
+                )
+            )
+            .hasCauseInstanceOf(FeignException.class);
+
+    }
+
+    private Map<String, Object> getRequiredVariables() {
+        return
+            Map.of(
+                "caseId", CASE_ID,
+                "name", TASK_NAME
+            );
+
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.camunda.bpm.clients.TaskConfigurationServiceApi;
 import uk.gov.hmcts.reform.camunda.bpm.domain.request.ConfigureTaskRequest;
 import uk.gov.hmcts.reform.camunda.bpm.domain.response.ConfigureTaskResponse;
-import uk.gov.hmcts.reform.camunda.bpm.exception.ServerErrorException;
 
 import java.util.Map;
 import java.util.UUID;
@@ -156,22 +155,17 @@ public class TaskConfigurationServiceTest {
     }
 
     @Test
-    public void should_throw_server_error_exception_when_feign_exception() {
+    public void should_set_task_state_to_unconfigured_when_task_configuration_feign_exception() {
 
         when(taskConfigurationServiceApi.configureTask(
             eq(SERVICE_TOKEN),
             eq(taskId),
             any(ConfigureTaskRequest.class)
         )).thenThrow(FeignException.FeignServerException.class);
-        assertThatThrownBy(() -> taskConfigurationService.configureTask(testTask))
-            .isInstanceOf(ServerErrorException.class)
-            .hasMessage(
-                String.format(
-                    "There was a problem configuring the task with id: %s",
-                    taskId
-                )
-            )
-            .hasCauseInstanceOf(FeignException.class);
+
+        taskConfigurationService.configureTask(testTask);
+
+        verify(testTask, times(1)).setVariable("taskState", "unconfigured");
 
     }
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -47,3 +47,13 @@ camundaAccess:
     batchAccess: false
     decisionDefinitionAccess: true
     optimiseAccess: false
+
+idam:
+  s2s-auth:
+    url: ${S2S_URL:http://localhost:4552}
+    name: ${S2S_NAME_CAMUNDA_BPM:camunda_bpm}
+    secret: ${S2S_SECRET_CAMUNDA_BPM:AAAAAAAAAAAAAAAA}
+
+task-configuration-api:
+  url: ${TASK_CONFIGURATION_URL:http://localhost:8091}
+

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   flyway:
     enabled: false
   security:

--- a/src/testUtils/java/uk/gov/hmcts/reform/camunda/bpm/SpringBootIntegrationBaseTest.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/camunda/bpm/SpringBootIntegrationBaseTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.camunda.bpm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@ActiveProfiles("integration")
+@RunWith(SpringRunner.class)
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest(classes = CamundaApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class SpringBootIntegrationBaseTest {
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-113

### Change description ###


Added task event listener that calls task-configuration service to retrieve configuration before creating the task in the database.

Added s2s integration to generate service tokens before calling task-configuration.
Added wa-task-configuration integation.
Added FeignRetryPolicy to attempt to get configuration up to 3 times.
Added unit tests and integration test.
Setup integration tests.
Added S2S token generation and secret.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
