### PR TITLE
RWA-514: Migrating to task variables

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/EventHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/EventHandlerConfiguration.java
@@ -31,15 +31,15 @@ class EventHandlerConfiguration {
     @EventListener
     public void onTaskCreatedEvent(DelegateTask delegateTask) {
 
-        if (autoConfigureTaskEnabled) {
-            // Avoid the first 2 demo tasks that get created for testing purposes on application startup
-            if (!TEST_PURPOSES_ASSIGNEE_ID.equals(delegateTask.getAssignee())
-                && CREATE_EVENT.equals(delegateTask.getEventName())) {
+        if (CREATE_EVENT.equals(delegateTask.getEventName())) {
+            if (autoConfigureTaskEnabled) {
+                // Avoid the first 2 demo tasks that get created for testing purposes on application startup
+                if (!TEST_PURPOSES_ASSIGNEE_ID.equals(delegateTask.getAssignee())) {
 
-                LOG.info(
-                    "Create event received, attempting to configure task with id: {}",
-                    delegateTask.getId()
-                );
+                    LOG.info(
+                        "Create event received, attempting to configure task with id: {}",
+                        delegateTask.getId()
+                    );
 
                 /*
                  Uses DelegateTask as it is a mutable object
@@ -48,9 +48,13 @@ class EventHandlerConfiguration {
                  when this event is triggered
                  */
 
-                taskConfigurationService.configureTask(delegateTask);
+                    taskConfigurationService.configureTask(delegateTask);
+                }
+            } else {
+                LOG.info(
+                    "Create event received. Event processed but not handled. auto configuration flag was disabled"
+                );
             }
         }
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/EventHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/config/EventHandlerConfiguration.java
@@ -41,12 +41,12 @@ class EventHandlerConfiguration {
                         delegateTask.getId()
                     );
 
-                /*
-                 Uses DelegateTask as it is a mutable object
-                 Call wa-task-configuration to retrieve configuration for a tasks.
-                 The reason it is done in this way is because the tasks does not yet exist in the database
-                 when this event is triggered
-                 */
+                    /*
+                     Uses DelegateTask as it is a mutable object
+                     Call wa-task-configuration to retrieve configuration for a tasks.
+                     The reason it is done in this way is because the tasks does not yet exist in the database
+                     when this event is triggered
+                     */
 
                     taskConfigurationService.configureTask(delegateTask);
                 }

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationService.java
@@ -42,9 +42,9 @@ public class TaskConfigurationService {
             () -> performConfigureTaskAction(task.getId(), new ConfigureTaskRequest(variables)
             ));
 
-        // If the call resulted in a non-retryable exception update task state process variable to unconfigured only.
+        // If the call resulted in a non-retryable exception update task state to unconfigured only.
         if (response == null) {
-            task.setVariable("taskState", "unconfigured");
+            task.setVariableLocal("taskState", "unconfigured");
         } else {
             // If response contained an assignee also update mutable object's assignee
             if (response.getAssignee() != null) {

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
@@ -82,7 +82,7 @@ public class TaskConfigurationServiceTest {
                 "autoAssigned", false,
                 "taskSystem", "SELF",
                 "name", TASK_NAME,
-                "taskType", "aTaskId"
+                "taskType", "reviewTheAppeal"
             );
 
         when(taskConfigurationServiceApi.configureTask(
@@ -110,7 +110,7 @@ public class TaskConfigurationServiceTest {
                 "autoAssigned", false,
                 "taskSystem", "SELF",
                 "name", TASK_NAME,
-                "taskType", "aTaskId"
+                "taskType", "reviewTheAppeal"
             );
 
         verify(testTask, times(0)).setAssignee(any());
@@ -134,7 +134,7 @@ public class TaskConfigurationServiceTest {
                 "securityClassification", "PUBLIC",
                 "autoAssigned", true,
                 "taskSystem", "SELF",
-                "taskType", "aTaskId",
+                "taskType", "reviewTheAppeal",
                 "name", TASK_NAME
             );
 
@@ -163,7 +163,7 @@ public class TaskConfigurationServiceTest {
                 "autoAssigned", true,
                 "taskSystem", "SELF",
                 "name", TASK_NAME,
-                "taskType", "aTaskId"
+                "taskType", "reviewTheAppeal"
             );
 
         verify(testTask, times(1)).setAssignee(assignee);

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +29,7 @@ public class TaskConfigurationServiceTest {
 
 
     private static final int MAX_RETRIES = 3;
+    private static final String TASK_ID = "reviewTheAppeal";
     private static final String CASE_ID = "CASE_123456789";
     private static final String TASK_NAME = "A task name";
     private static final String SERVICE_TOKEN = "Bearer SERVICE_TOKEN";
@@ -113,6 +115,8 @@ public class TaskConfigurationServiceTest {
 
         verify(testTask, times(0)).setAssignee(any());
         verify(testTask, times(1)).setVariablesLocal(expectedVariables);
+        verify(testTask, never()).setVariable(any(), any());
+        verify(testTask, never()).setVariables(any());
 
     }
 
@@ -164,6 +168,8 @@ public class TaskConfigurationServiceTest {
 
         verify(testTask, times(1)).setAssignee(assignee);
         verify(testTask, times(1)).setVariablesLocal(expectedVariables);
+        verify(testTask, never()).setVariable(any(), any());
+        verify(testTask, never()).setVariables(any());
 
     }
 
@@ -179,12 +185,15 @@ public class TaskConfigurationServiceTest {
         taskConfigurationService.configureTask(testTask);
 
         verify(testTask, times(1)).setVariableLocal("taskState", "unconfigured");
+        verify(testTask, never()).setVariable(any(), any());
+        verify(testTask, never()).setVariables(any());
 
     }
 
     private Map<String, Object> getRequiredVariables() {
         return
             Map.of(
+                "taskId", TASK_ID,
                 "caseId", CASE_ID,
                 "name", TASK_NAME
             );

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
@@ -178,7 +178,7 @@ public class TaskConfigurationServiceTest {
 
         taskConfigurationService.configureTask(testTask);
 
-        verify(testTask, times(1)).setVariable("taskState", "unconfigured");
+        verify(testTask, times(1)).setVariableLocal("taskState", "unconfigured");
 
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/services/TaskConfigurationServiceTest.java
@@ -78,7 +78,10 @@ public class TaskConfigurationServiceTest {
                 "caseId", CASE_ID,
                 "securityClassification", "PUBLIC",
                 "autoAssigned", false,
-                "taskSystem", "SELF");
+                "taskSystem", "SELF",
+                "name", TASK_NAME,
+                "taskType", "aTaskId"
+            );
 
         when(taskConfigurationServiceApi.configureTask(
             eq(SERVICE_TOKEN),
@@ -104,11 +107,12 @@ public class TaskConfigurationServiceTest {
                 "securityClassification", "PUBLIC",
                 "autoAssigned", false,
                 "taskSystem", "SELF",
-                "name", TASK_NAME
+                "name", TASK_NAME,
+                "taskType", "aTaskId"
             );
 
         verify(testTask, times(0)).setAssignee(any());
-        verify(testTask, times(1)).setVariables(expectedVariables);
+        verify(testTask, times(1)).setVariablesLocal(expectedVariables);
 
     }
 
@@ -125,7 +129,10 @@ public class TaskConfigurationServiceTest {
                 "caseId", CASE_ID,
                 "securityClassification", "PUBLIC",
                 "autoAssigned", true,
-                "taskSystem", "SELF");
+                "taskSystem", "SELF",
+                "taskType", "aTaskId",
+                "name", TASK_NAME
+            );
 
         when(taskConfigurationServiceApi.configureTask(
             eq(SERVICE_TOKEN),
@@ -151,11 +158,12 @@ public class TaskConfigurationServiceTest {
                 "securityClassification", "PUBLIC",
                 "autoAssigned", true,
                 "taskSystem", "SELF",
-                "name", TASK_NAME
+                "name", TASK_NAME,
+                "taskType", "aTaskId"
             );
 
         verify(testTask, times(1)).setAssignee(assignee);
-        verify(testTask, times(1)).setVariables(expectedVariables);
+        verify(testTask, times(1)).setVariablesLocal(expectedVariables);
 
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-514

### Change description ###

Migrate to the use of task variables setting variables under local scope on task creation event listener.
Remove unnecessary variable merging logic.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
