### PR TITLE
DTSPO-6156 - Upgrade Camunda Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ dependencyManagement {
         mavenBom 'org.camunda.bpm.extension.springboot:camunda-bpm-spring-boot-starter-bom:2.2.0'
     }
     imports {
-        mavenBom 'org.camunda.bpm:camunda-bom:7.16.7-ee'
+        mavenBom 'org.camunda.bpm:camunda-bom:7.17.0-ee'
     }
     dependencies {
         // CVE-2020-26945 - Mishandles deserialization of object streams.

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'org.camunda.spin:camunda-spin-dataformat-all:1.16.0'
     implementation 'org.camunda.bpm:camunda-engine-plugin-spin'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.postgresql:postgresql:42.3.3'
+    implementation 'org.postgresql:postgresql:42.4.1'
     implementation 'org.flywaydb:flyway-core:8.5.13'
     // JAX-B dependencies for JDK 9+
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '3.0.2'


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-6156


### Change description ###
- Upgrade Camunda Version (7.16.0 -> 7.17.0)
- Upgrade PostgreSQL to fix failed security check in pipeline (42.3.3 -> 42.4.1)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
