### PR TITLE
DTSPO-6156 - Remove app insights instrumentation key

### DIFF
--- a/charts/camunda-bpm/Chart.yaml
+++ b/charts/camunda-bpm/Chart.yaml
@@ -1,6 +1,6 @@
 name: camunda-bpm
 home: https://github.com/hmcts/camunda-bpm
-version: 0.0.26
+version: 0.0.28
 description: Camunda bpm
 maintainers:
   - name: HMCTS Platform Operations team

--- a/charts/camunda-bpm/values.yaml
+++ b/charts/camunda-bpm/values.yaml
@@ -11,8 +11,6 @@ java:
           alias: CAMUNDA_ADMIN_PASSWORD
         - name: s2s-secret-camunda-bpm
           alias: S2S_SECRET_CAMUNDA_BPM
-        - name: AppInsightsInstrumentationKey
-          alias: azure.application-insights.instrumentation-key
         - name: app-insights-connection-string
           alias: app-insights-connection-string
   environment:


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-6156


### Change description ###
- Remove app insights instrumentation key as app insights has now been migrated to connection strings


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
