### PR TITLE
Remove first and last name

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/filter/SpringSecurityWebappAuthenticationProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/filter/SpringSecurityWebappAuthenticationProvider.java
@@ -26,8 +26,6 @@ import static java.util.Objects.requireNonNull;
 @SuppressWarnings("unused")
 public class SpringSecurityWebappAuthenticationProvider extends SpringSecurityBaseAuthenticationProvider {
 
-    public static final String GIVEN_NAME = "given_name";
-    public static final String FAMILY_NAME = "family_name";
     public static final String UNIQUE_NAME = "unique_name";
     public static final String GROUPS_ATTRIBUTE = "groups";
     public static final String DEFAULT_GROUP_NAME = "All users";
@@ -96,8 +94,6 @@ public class SpringSecurityWebappAuthenticationProvider extends SpringSecurityBa
                             IdentityService identityService) {
 
         User user = identityService.newUser(id);
-        user.setFirstName(requireNonNull(attributes.get(GIVEN_NAME)).toString());
-        user.setLastName(requireNonNull(attributes.get(FAMILY_NAME)).toString());
         user.setEmail(requireNonNull(attributes.get(UNIQUE_NAME)).toString());
 
         identityService.deleteUser(id);

--- a/src/test/java/uk/gov/hmcts/reform/camunda/bpm/filter/webapp/SpringSecurityWebappAuthenticationProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/camunda/bpm/filter/webapp/SpringSecurityWebappAuthenticationProviderTest.java
@@ -199,8 +199,6 @@ public class SpringSecurityWebappAuthenticationProviderTest {
     private Authentication getAuthenticationContextWithoutPrincipalName(List<String> groups, String name) {
         Map<String, Object> attributes = ImmutableMap.of(
             "groups", groups,
-            SpringSecurityWebappAuthenticationProvider.GIVEN_NAME,name,
-            SpringSecurityWebappAuthenticationProvider.FAMILY_NAME,name,
             SpringSecurityWebappAuthenticationProvider.UNIQUE_NAME,name
 
         );


### PR DESCRIPTION
Trying to remove these two as if user does not have these assigned in Azure, camunda default page redirects to whitelabel error page, and not sure they are fully being used anyway

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
