### PR TITLE
Extract first/last name from name if not set

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/filter/SpringSecurityWebappAuthenticationProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/filter/SpringSecurityWebappAuthenticationProvider.java
@@ -28,6 +28,8 @@ public class SpringSecurityWebappAuthenticationProvider extends SpringSecurityBa
 
     public static final String GIVEN_NAME = "given_name";
     public static final String FAMILY_NAME = "family_name";
+
+    public static final String NAME = "name";
     public static final String UNIQUE_NAME = "unique_name";
     public static final String GROUPS_ATTRIBUTE = "groups";
     public static final String DEFAULT_GROUP_NAME = "All users";
@@ -96,7 +98,7 @@ public class SpringSecurityWebappAuthenticationProvider extends SpringSecurityBa
                             IdentityService identityService) {
 
         User user = identityService.newUser(id);
-        String name = (String) attributes.get("name");
+        String name = (String) attributes.get(NAME);
         user.setFirstName(getFirstName(attributes, name));
         user.setLastName(getLastName(attributes, name));
         user.setEmail(requireNonNull(attributes.get(UNIQUE_NAME)).toString());

--- a/src/main/java/uk/gov/hmcts/reform/camunda/bpm/filter/SpringSecurityWebappAuthenticationProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/camunda/bpm/filter/SpringSecurityWebappAuthenticationProvider.java
@@ -96,12 +96,39 @@ public class SpringSecurityWebappAuthenticationProvider extends SpringSecurityBa
                             IdentityService identityService) {
 
         User user = identityService.newUser(id);
-        user.setFirstName(requireNonNull(attributes.get(GIVEN_NAME)).toString());
-        user.setLastName(requireNonNull(attributes.get(FAMILY_NAME)).toString());
+        String name = (String) attributes.get("name");
+        user.setFirstName(getFirstName(attributes, name));
+        user.setLastName(getLastName(attributes, name));
         user.setEmail(requireNonNull(attributes.get(UNIQUE_NAME)).toString());
 
         identityService.deleteUser(id);
         identityService.saveUser(user);
+    }
+
+    private static String getFirstName(Map<String, Object> attributes, String name) {
+        String firstName = (String) attributes.get(GIVEN_NAME);
+        if (firstName == null) {
+            // assumes that if a name has a comma in it is in the format "LastName, FirstName"
+            if (name.contains(",")) {
+                firstName = name.split(",")[1].trim();
+            } else {
+                firstName = name.split(" ")[0].trim();
+            }
+        }
+        return firstName;
+    }
+
+    private static String getLastName(Map<String, Object> attributes, String name) {
+        String lastName = (String) attributes.get(FAMILY_NAME);
+        if (lastName == null) {
+            // assumes that if a name has a comma in it is in the format "LastName, FirstName"
+            if (name.contains(",")) {
+                lastName = name.split(",")[0].trim();
+            } else {
+                lastName = name.split(" ")[1].trim();
+            }
+        }
+        return lastName;
     }
 
 


### PR DESCRIPTION
It's not perfect but it will at least allow users to login if they don't have a first / last name set.
Should work with justice.gov.uk formats just fine

Closes https://github.com/hmcts/camunda-bpm/pull/498