### PR TITLE
DTSPO-13897 - Add job history cleanup values

### DIFF
--- a/charts/camunda-bpm/Chart.yaml
+++ b/charts/camunda-bpm/Chart.yaml
@@ -1,6 +1,6 @@
 name: camunda-bpm
 home: https://github.com/hmcts/camunda-bpm
-version: 0.0.30
+version: 0.0.31
 description: Camunda bpm
 maintainers:
   - name: HMCTS Platform Operations team

--- a/charts/camunda-bpm/values.preview.template.yaml
+++ b/charts/camunda-bpm/values.preview.template.yaml
@@ -14,8 +14,5 @@ java:
     CAMUNDA_DB_CONN_OPTIONS: ""
     S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     TASK_MANAGEMENT_API_URL: "http://wa-task-management-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
-    CAMUNDA_BATCH_HISTORY_TTL: "P30D"
-    CAMUNDA_HISTORY_CLEANUP_START_TIME: "18:00"
-    CAMUNDA_HISTORY_CLEANUP_END_TIME: "19:30"
   postgresql:
     enabled: true

--- a/charts/camunda-bpm/values.preview.template.yaml
+++ b/charts/camunda-bpm/values.preview.template.yaml
@@ -14,5 +14,6 @@ java:
     CAMUNDA_DB_CONN_OPTIONS: ""
     S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     TASK_MANAGEMENT_API_URL: "http://wa-task-management-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    CAMUNDA_BATCH_HISTORY_TTL: "P30D"
   postgresql:
     enabled: true

--- a/charts/camunda-bpm/values.preview.template.yaml
+++ b/charts/camunda-bpm/values.preview.template.yaml
@@ -15,5 +15,7 @@ java:
     S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     TASK_MANAGEMENT_API_URL: "http://wa-task-management-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     CAMUNDA_BATCH_HISTORY_TTL: "P30D"
+    CAMUNDA_HISTORY_CLEANUP_START_TIME: "18:00"
+    CAMUNDA_HISTORY_CLEANUP_END_TIME: "19:30"
   postgresql:
     enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,10 @@ camunda:
     generic-properties:
       properties:
         generalResourceWhitelistPattern: '[.a-zA-Z0-9@_-]+'
+        historyCleanupStrategy: endTimeBased
+        fridayHistoryCleanupBatchWindowStartTime: "03:00"
+        fridayHistoryCleanupBatchWindowEndTime: "06:00"
+        historyCleanupBatchSize: 300
     database:
 #    We manage database versioning through flyway. Using this can cause the schema to go out of sync.
       schema-update: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,11 +42,11 @@ camunda:
     generic-properties:
       properties:
         generalResourceWhitelistPattern: '[.a-zA-Z0-9@_-]+'
-        historyCleanupStrategy: endTimeBased
-        historyCleanupBatchWindowStartTime: "18:00"
-        historyCleanupBatchWindowEndTime: "19:30"
+        historyCleanupStrategy: ${CAMUNDA_HISTORY_CLEANUP_STRATEGY:endTimeBased}
+        historyCleanupBatchWindowStartTime: ${CAMUNDA_HISTORY_CLEANUP_START_TIME:18:00}
+        historyCleanupBatchWindowEndTime: ${CAMUNDA_HISTORY_CLEANUP_END_TIME:19:30}
         historyCleanupBatchSize: 300
-        batchOperationHistoryTimeToLive: "P5D"
+        batchOperationHistoryTimeToLive: ${CAMUNDA_BATCH_HISTORY_TTL:P5D}
     database:
 #    We manage database versioning through flyway. Using this can cause the schema to go out of sync.
       schema-update: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,8 +43,8 @@ camunda:
       properties:
         generalResourceWhitelistPattern: '[.a-zA-Z0-9@_-]+'
         historyCleanupStrategy: endTimeBased
-        fridayHistoryCleanupBatchWindowStartTime: "03:00"
-        fridayHistoryCleanupBatchWindowEndTime: "06:00"
+        historyCleanupBatchWindowStartTime: "03:00"
+        historyCleanupBatchWindowEndTime: "06:00"
         historyCleanupBatchSize: 300
     database:
 #    We manage database versioning through flyway. Using this can cause the schema to go out of sync.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,9 +43,10 @@ camunda:
       properties:
         generalResourceWhitelistPattern: '[.a-zA-Z0-9@_-]+'
         historyCleanupStrategy: endTimeBased
-        historyCleanupBatchWindowStartTime: "03:00"
-        historyCleanupBatchWindowEndTime: "06:00"
+        historyCleanupBatchWindowStartTime: "18:00"
+        historyCleanupBatchWindowEndTime: "19:30"
         historyCleanupBatchSize: 300
+        batchOperationHistoryTimeToLive: "P5D"
     database:
 #    We manage database versioning through flyway. Using this can cause the schema to go out of sync.
       schema-update: false


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13897

### Change description ###
Adding the following properties to cleanup the job history table in the camunda database which is nearly 200GB in size.

`historyCleanupStrategy`

Controls which [History cleanup](https://docs.camunda.org/manual/7.10/user-guide/process-engine/history/#history-cleanup) strategy is used. `removalTimeBased` requires a TTL to be set on jobs which we do not currently have. `endTimeBased` uses job end time which does not require a TTL to be set.

`historyCleanupBatchWindowStartTime`

Start of time window during which cleanup job should run

`historyCleanupBatchWindowEndTime`

End of time window during which cleanup job should run

`historyCleanupBatchSize`

Defines the amount of top-level objects (e.g., historic process instances) to be removed at once. Default and maximum value is 500

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
