### PR TITLE
take perftest out of sync for manual testing of params

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -46,6 +46,6 @@ withPipeline(type, product, component) {
     env.TASK_MANAGEMENT_API_URL = "http://wa-task-management-api-aat.service.core-compute-aat.internal"
 
     enableDbMigration("camunda")
-    def branchesToSync = ['demo', 'perftest', 'ithc']
+    def branchesToSync = ['demo', 'ithc']
     syncBranchesWithMaster(branchesToSync)
 }


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16736


### Change description ###

- take perftest out of sync with master
- enables tweaking of params manually without them being overwritten - in particular looking at shared_buffers which is set very high by the module over the [microsoft recommendation](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-high-memory-utilization#shared-buffers) of max 25%


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
