### PR TITLE
Adding an input variable for server configuration

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,4 @@
 pgsql_storage_mb = "524288"
 pgsql_server_configuration = {
-        "shared_buffers": 1310720
+        "shared_buffers": "1310720"
 }

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,1 +1,4 @@
 pgsql_storage_mb = "524288"
+pgsql_server_configuration = {
+        "shared_buffers": 1310720
+}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,4 @@
 pgsql_storage_mb = "524288"
-pgsql_server_configuration = {
-        "shared_buffers": "1310720"
-}
+# pgsql_server_configuration = {
+#         "shared_buffers": "1310720"
+# }

--- a/infrastructure/db.tf
+++ b/infrastructure/db.tf
@@ -25,7 +25,7 @@ module "postgresql_flexible" {
   pgsql_server_configuration = [
     {
       name  = "shared_buffers"
-      value = var.pgsql_server_configuration.shared_buffers
+      value = lookup(var.pgsql_server_configuration, "shared_buffers")
     },
     {
       name  = "work_mem"
@@ -61,7 +61,7 @@ module "postgresql_flexible" {
     },
     {
       name  = "max_wal_size"
-      value = var.pgsql_server_configuration.max_wal_size
+      value = lookup(var.pgsql_server_configuration, "max_wal_size")
     },
     {
       name  = "effective_io_concurrency"

--- a/infrastructure/db.tf
+++ b/infrastructure/db.tf
@@ -25,7 +25,7 @@ module "postgresql_flexible" {
   pgsql_server_configuration = [
     {
       name  = "shared_buffers"
-      value = "2097152"
+      value = var.pgsql_server_configuration.shared_buffers
     },
     {
       name  = "work_mem"
@@ -61,7 +61,7 @@ module "postgresql_flexible" {
     },
     {
       name  = "max_wal_size"
-      value = "4096"
+      value = var.pgsql_server_configuration.max_wal_size
     },
     {
       name  = "effective_io_concurrency"

--- a/infrastructure/ithc.tfvars
+++ b/infrastructure/ithc.tfvars
@@ -1,0 +1,3 @@
+pgsql_server_configuration = {
+        "shared_buffers": "524288"
+}

--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -1,5 +1,5 @@
 pgsql_storage_mb = "262144"
 pgsql_sku        = "GP_Standard_D4s_v3"
-pgsql_server_configuration = {
-        "shared_buffers": "1310720"
-}
+# pgsql_server_configuration = {
+#         "shared_buffers": "1310720"
+# }

--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -1,5 +1,5 @@
 pgsql_storage_mb = "262144"
 pgsql_sku        = "GP_Standard_D4s_v3"
 pgsql_server_configuration = {
-        "shared_buffers": 1310720
+        "shared_buffers": "1310720"
 }

--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -1,2 +1,5 @@
 pgsql_storage_mb = "262144"
 pgsql_sku        = "GP_Standard_D4s_v3"
+pgsql_server_configuration = {
+        "shared_buffers": 1310720
+}

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,4 +1,4 @@
 pgsql_storage_mb = "262144"
 pgsql_server_configuration = {
-        "shared_buffers": 1310720
+        "shared_buffers": "1310720"
 }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,4 @@
 pgsql_storage_mb = "262144"
+pgsql_server_configuration = {
+        "shared_buffers": 1310720
+}

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,4 +1,4 @@
 pgsql_storage_mb = "262144"
-pgsql_server_configuration = {
-        "shared_buffers": "1310720"
-}
+# pgsql_server_configuration = {
+#         "shared_buffers": "1310720"
+# }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -41,7 +41,7 @@ variable "pgsql_sku" {
 variable "pgsql_server_configuration" {
   description = "Map of the pgsql server configuration options"
   type = map(object({
-    shared_buffers  = optional(number, 786432)
-    max_wal_size    = optional(number, 4096)
+    shared_buffers  = optional(string, "786432")
+    max_wal_size    = optional(string, "4096")
   }))
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -37,3 +37,11 @@ variable "pgsql_sku" {
   description = "SKU for Postgresql DB"
   default     = "GP_Standard_D2s_v3"
 }
+
+variable "pgsql_server_configuration" {
+  description = "Map of the pgsql server configuration options"
+  type = map(object({
+    shared_buffers  = optional(number, 786432)
+    max_wal_size    = optional(number, 4096)
+  }))
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -39,9 +39,10 @@ variable "pgsql_sku" {
 }
 
 variable "pgsql_server_configuration" {
-  description = "Map of the pgsql server configuration options"
-  type = map(object({
+  description = "pgsql server configuration options"
+  type = object({
     shared_buffers  = optional(string, "786432")
     max_wal_size    = optional(string, "4096")
-  }))
+  })
+  default = {}
 }


### PR DESCRIPTION
### Change description ###
Adding an input variable for server configuration, contains only shared buffers and max WAL size but can be expanded to make it easier for environment specific values
