### PR TITLE
Flex server expanded subnet migration

### DIFF
--- a/infrastructure/db.tf
+++ b/infrastructure/db.tf
@@ -206,21 +206,3 @@ resource "azurerm_key_vault_secret" "postgres-v15-password" {
   value        = module.postgresql_flexible_expanded.password
   key_vault_id = module.vault.key_vault_id
 }
-
-resource "azurerm_key_vault_secret" "postgres-v15-host" {
-  name         = "bpm-POSTGRES-V15-HOST"
-  value        = module.postgresql_flexible_expanded.fqdn
-  key_vault_id = module.vault.key_vault_id
-}
-
-resource "azurerm_key_vault_secret" "postgres-v15-port" {
-  name         = "bpm-POSTGRES-V15-PORT"
-  value        = "5432"
-  key_vault_id = module.vault.key_vault_id
-}
-
-resource "azurerm_key_vault_secret" "postgres-v15-database" {
-  name         = "bpm-POSTGRES-V15-DATABASE"
-  value        = "camunda"
-  key_vault_id = module.vault.key_vault_id
-}

--- a/infrastructure/db.tf
+++ b/infrastructure/db.tf
@@ -110,3 +110,117 @@ resource "azurerm_key_vault_secret" "postgres-database" {
   value        = "camunda"
   key_vault_id = module.vault.key_vault_id
 }
+
+module "postgresql_flexible_expanded" {
+  providers = {
+    azurerm.postgres_network = azurerm.postgres_network
+  }
+
+  source               = "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"
+  env                  = var.env
+  product              = var.product
+  name                 = "hmcts-${var.product}-v15-flexible"
+  component            = var.component
+  business_area        = "CFT"
+  location             = var.location
+  pgsql_admin_username = "camundaadmin"
+  pgsql_storage_mb     = var.pgsql_storage_mb
+  pgsql_sku            = var.pgsql_sku
+  create_mode          = var.pgsql_create_mode
+  subnet_suffix        = "expanded"
+
+  common_tags          = var.common_tags
+  admin_user_object_id = var.jenkins_AAD_objectId
+  pgsql_databases = [
+    {
+      name : "camunda"
+    }
+  ]
+  // server_configuration values set based on SKU (CPU/RAM) and Max Connections
+  pgsql_server_configuration = [
+    {
+      name  = "shared_buffers"
+      value = lookup(var.pgsql_server_configuration, "shared_buffers")
+    },
+    {
+      name  = "work_mem"
+      value = "7489"
+    },
+    {
+      name  = "maintenance_work_mem"
+      value = "512000"
+    },
+    {
+      name  = "effective_cache_size"
+      value = "3932160"
+    },
+    {
+      name  = "max_parallel_workers"
+      value = "0"
+    },
+    {
+      name  = "max_parallel_workers_per_gather"
+      value = "0"
+    },
+    {
+      name  = "random_page_cost"
+      value = "1.1"
+    },
+    {
+      name  = "wal_buffers"
+      value = "16384"
+    },
+    {
+      name  = "min_wal_size"
+      value = "1024"
+    },
+    {
+      name  = "max_wal_size"
+      value = lookup(var.pgsql_server_configuration, "max_wal_size")
+    },
+    {
+      name  = "effective_io_concurrency"
+      value = "200"
+    },
+    {
+      name  = "backslash_quote"
+      value = "on"
+    },
+    {
+      name  = "azure.extensions"
+      value = "PG_BUFFERCACHE,PG_STAT_STATEMENTS,PLPGSQL"
+    }
+  ]
+  pgsql_firewall_rules = []
+  pgsql_version        = "15"
+}
+
+resource "azurerm_key_vault_secret" "postgres-v15-user" {
+  name         = "bpm-POSTGRES-V15-USER"
+  value        = module.postgresql_flexible_expanded.username
+  key_vault_id = module.vault.key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "postgres-v15-password" {
+  name         = "bpm-POSTGRES-V15-PASS"
+  value        = module.postgresql_flexible_expanded.password
+  key_vault_id = module.vault.key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "postgres-v15-host" {
+  name         = "bpm-POSTGRES-V15-HOST"
+  value        = module.postgresql_flexible_expanded.fqdn
+  key_vault_id = module.vault.key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "postgres-v15-port" {
+  name         = "bpm-POSTGRES-V15-PORT"
+  value        = "5432"
+  key_vault_id = module.vault.key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "postgres-v15-database" {
+  name         = "bpm-POSTGRES-V15-DATABASE"
+  value        = "camunda"
+  key_vault_id = module.vault.key_vault_id
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17274


### Change description ###
Creating replica flexible servers in the expanded subnet as old aat one ran out of addresses. Moving all envs for consistency. 

Will use pg_dump and pg_restore to migrate data from old servers to the new ones. Have done a test run on plum.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
